### PR TITLE
change show and hide to only remove or add class

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -617,11 +617,11 @@ function roomIsReady() {
 }
 
 function hide(elem) {
-    elem.className = 'hidden';
+    elem.classList.add('hidden');
 }
 
 function show(elem) {
-    elem.className = '';
+    elem.classList.remove('hidden');
 }
 
 function setColor(elem, color) {


### PR DESCRIPTION
I was adding a custom button and couldn't figure out why the classes were being removed. I found this block of code and thought it would work the same if the class for hiding was just added/removed instead of clearing other classes.