### PR TITLE
[mirotalksfu] - allow name storage per room

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -394,8 +394,8 @@ function whoAreYou() {
     }
 
     let default_name = window.localStorage.peer_name ? window.localStorage.peer_name : '';
-    if (getCookie(room_id + "_name")) {
-        default_name = getCookie(room_id + "_name");
+    if (getCookie(room_id + '_name')) {
+        default_name = getCookie(room_id + '_name');
     }
 
     Swal.fire({
@@ -422,10 +422,10 @@ function whoAreYou() {
         },
         inputValidator: (name) => {
             if (!name) return 'Please enter your name';
-            if (!getCookie(room_id + "_name")) {
+            if (!getCookie(room_id + '_name')) {
                 window.localStorage.peer_name = name;
             }
-            setCookie(room_id + "_name", name, 30);
+            setCookie(room_id + '_name', name, 30);
             peer_name = name;
         },
     }).then(() => {
@@ -1265,21 +1265,21 @@ function openURL(url, blank = false) {
 }
 
 function setCookie(name, value, expDays) {
-        let date = new Date();
-        date.setTime(date.getTime() + (expDays * 24 * 60 * 60 * 1000));
-        const expires = "expires=" + date.toUTCString();
-        document.cookie = name + "=" + value + "; " + expires + "; path=/";
+    let date = new Date();
+    date.setTime(date.getTime() + expDays * 24 * 60 * 60 * 1000);
+    const expires = 'expires=' + date.toUTCString();
+    document.cookie = name + '=' + value + '; ' + expires + '; path=/';
 }
 
 function getCookie(cName) {
-      const name = cName + "=";
-      const cDecoded = decodeURIComponent(document.cookie);
-      const cArr = cDecoded .split('; ');
-      let res;
-      cArr.forEach(val => {
-          if (val.indexOf(name) === 0) res = val.substring(name.length);
-      })
-      return res;
+    const name = cName + '=';
+    const cDecoded = decodeURIComponent(document.cookie);
+    const cArr = cDecoded.split('; ');
+    let res;
+    cArr.forEach((val) => {
+        if (val.indexOf(name) === 0) res = val.substring(name.length);
+    });
+    return res;
 }
 
 // ####################################################

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -393,6 +393,11 @@ function whoAreYou() {
         return;
     }
 
+    let default_name = window.localStorage.peer_name ? window.localStorage.peer_name : '';
+    if (getCookie(room_id + "_name")) {
+        default_name = getCookie(room_id + "_name");
+    }
+
     Swal.fire({
         allowOutsideClick: false,
         allowEscapeKey: false,
@@ -401,7 +406,7 @@ function whoAreYou() {
         imageUrl: image.username,
         input: 'text',
         inputPlaceholder: 'Enter your name',
-        inputValue: window.localStorage.peer_name ? window.localStorage.peer_name : '',
+        inputValue: default_name,
         html: `<br />
         <div style="overflow: hidden;">
             <button id="initAudioButton" class="fas fa-microphone" onclick="handleAudio(event)"></button>
@@ -417,12 +422,15 @@ function whoAreYou() {
         },
         inputValidator: (name) => {
             if (!name) return 'Please enter your name';
+            if (!getCookie(room_id + "_name")) {
+                window.localStorage.peer_name = name;
+            }
+            setCookie(room_id + "_name", name, 30);
             peer_name = name;
         },
     }).then(() => {
         getPeerInfo();
         joinRoom(peer_name, room_id);
-        window.localStorage.peer_name = peer_name;
     });
 
     if (!DetectRTC.isMobileDevice) {
@@ -1254,6 +1262,24 @@ function isIpad(userAgent) {
 
 function openURL(url, blank = false) {
     blank ? window.open(url, '_blank') : (window.location.href = url);
+}
+
+function setCookie(name, value, expDays) {
+        let date = new Date();
+        date.setTime(date.getTime() + (expDays * 24 * 60 * 60 * 1000));
+        const expires = "expires=" + date.toUTCString();
+        document.cookie = name + "=" + value + "; " + expires + "; path=/";
+}
+
+function getCookie(cName) {
+      const name = cName + "=";
+      const cDecoded = decodeURIComponent(document.cookie);
+      const cArr = cDecoded .split('; ');
+      let res;
+      cArr.forEach(val => {
+          if (val.indexOf(name) === 0) res = val.substring(name.length);
+      })
+      return res;
 }
 
 // ####################################################


### PR DESCRIPTION
Hi Miroslav,

I saw you did implement a name storage, which is definitely handsome.
I already prepared a PR regarding this feature but we were occupied with docker and I did not took the time to push it.
Remembering the user name is very convenient, but it could be more useful:
During my videocalls, I sometimes have to use my nickname, sometimes my real name, and sometimes my full name depending on the people I talk to.

Here is my proposal: I store the name used in a room inside a cookie for 30 days (localStorage does not expires). If I come back to this room, I get the previously used name (but does not update the default peer_name). 
If I change room, I create a 30 days cookie for this name in this rom and update the default peer_name, and so on…

What's your opinion on this ?