### PR TITLE
fix announcedIp in network mode host

### DIFF
--- a/app/src/config.template.js
+++ b/app/src/config.template.js
@@ -5,14 +5,16 @@ const ifaces = os.networkInterfaces();
 
 const getLocalIp = () => {
     let localIp = '127.0.0.1';
+    let checkIp = true;
     Object.keys(ifaces).forEach((ifname) => {
         for (const iface of ifaces[ifname]) {
             // Ignore IPv6 and 127.0.0.1
-            if (iface.family !== 'IPv4' || iface.internal !== false) {
+            if (iface.family !== 'IPv4' || iface.internal !== false || checkIp === false) {
                 continue;
             }
             // Set the local ip to the first IPv4 address found and exit the loop
             localIp = iface.address;
+            checkIp = false
             return;
         }
     });


### PR DESCRIPTION
When run mirotalk/sfu in network_mode: host and have some other docker network bridge
`version: '3'

services:
    mirotalksfu:
        image: mirotalk/sfu:latest
        # build:
        #     context: .
        #     dockerfile: Dockerfile
        container_name: mirotalksfu
        hostname: mirotalksfu
        restart: unless-stopped
        network_mode: host
        volumes:
            - ./app/src/config.template.js:/src/app/src/config.js:ro
            # These volumes are not mandatory, comment if you want to use it
            # - ./app/:/src/app/:ro
            # - ./public/:/src/public/:ro
        # ports:
        #     - '3010:3010/tcp'
        #     - '40000-40100:40000-40100/tcp'
        #     - '40000-40100:40000-40100/udp'`
it not get first IPv4 address found
![image](https://github.com/miroslavpejic85/mirotalksfu/assets/78783748/af01fb91-09ab-43cf-9f7c-da65b70f556c)
![image](https://github.com/miroslavpejic85/mirotalksfu/assets/78783748/a4fc213e-503a-45ca-9c13-9cd336e8917f)
Expected result is 192.168.1.24 