### PR TITLE
replace rawgit urls with jsdelivr

### DIFF
--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -88,7 +88,7 @@
 
         <script defer src="/socket.io/socket.io.js"></script>
         <script defer src="../sfu/MediasoupClient.js"></script>
-        <script defer src="https://rawgit.com/leizongmin/js-xss/master/dist/xss.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
         <script defer src="../js/LocalStorage.js"></script>
         <script defer src="../js/Rules.js"></script>
         <script defer src="../js/Helpers.js"></script>

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -88,7 +88,7 @@
 
         <script defer src="/socket.io/socket.io.js"></script>
         <script defer src="../sfu/MediasoupClient.js"></script>
-        <script defer src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/xss/dist/xss.min.js"></script>
         <script defer src="../js/LocalStorage.js"></script>
         <script defer src="../js/Rules.js"></script>
         <script defer src="../js/Helpers.js"></script>

--- a/public/views/landing.html
+++ b/public/views/landing.html
@@ -46,7 +46,7 @@
         <!-- <script async src="../js/Snow.js"></script> -->
         <script src="https://unpkg.com/animejs@3.0.1/lib/anime.min.js"></script>
         <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
-        <script src="https://rawgit.com/leizongmin/js-xss/master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
     </head>
     <body class="is-boxed has-animations">
         <div id="snow-container"></div>

--- a/public/views/landing.html
+++ b/public/views/landing.html
@@ -46,7 +46,7 @@
         <!-- <script async src="../js/Snow.js"></script> -->
         <script src="https://unpkg.com/animejs@3.0.1/lib/anime.min.js"></script>
         <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/xss/dist/xss.min.js"></script>
     </head>
     <body class="is-boxed has-animations">
         <div id="snow-container"></div>

--- a/public/views/login.html
+++ b/public/views/login.html
@@ -46,7 +46,7 @@
 
         <!-- xss -->
 
-        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/xss/dist/xss.min.js"></script>
 
         <!-- axios -->
 

--- a/public/views/login.html
+++ b/public/views/login.html
@@ -46,7 +46,7 @@
 
         <!-- xss -->
 
-        <script src="https://rawgit.com/leizongmin/js-xss/master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
 
         <!-- axios -->
 

--- a/public/views/newroom.html
+++ b/public/views/newroom.html
@@ -44,7 +44,7 @@
         <script async src="../js/Umami.js"></script>
         <script src="https://unpkg.com/animejs@3.0.1/lib/anime.min.js"></script>
         <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
-        <script src="https://rawgit.com/leizongmin/js-xss/master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
     </head>
     <body class="is-boxed has-animations">
         <div class="body-wrap">

--- a/public/views/newroom.html
+++ b/public/views/newroom.html
@@ -44,7 +44,7 @@
         <script async src="../js/Umami.js"></script>
         <script src="https://unpkg.com/animejs@3.0.1/lib/anime.min.js"></script>
         <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/xss/dist/xss.min.js"></script>
     </head>
     <body class="is-boxed has-animations">
         <div class="body-wrap">

--- a/public/views/permission.html
+++ b/public/views/permission.html
@@ -36,7 +36,7 @@
         <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
 
         <!-- xss -->
-        <script src="https://rawgit.com/leizongmin/js-xss/master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
     </head>
     <body class="is-boxed has-animations">
         <div class="body-wrap">

--- a/public/views/permission.html
+++ b/public/views/permission.html
@@ -36,7 +36,7 @@
         <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
 
         <!-- xss -->
-        <script src="https://cdn.jsdelivr.net/gh/leizongmin/js-xss@master/dist/xss.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/xss/dist/xss.min.js"></script>
     </head>
     <body class="is-boxed has-animations">
         <div class="body-wrap">


### PR DESCRIPTION
This PR removes the rawgit urls used to fetch the xss.js script in the html views and replaces them with jsdelivr URLs.

rawgit.com is deprecated and should not be used anymore.