### PR TITLE
Add tz offset to peer info

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -1046,6 +1046,7 @@ async function checkInitConfig() {
 function getPeerInfo() {
     peer_info = {
         join_data_time: getDataTimeString(),
+        join_tz_offset: new Date().getTimezoneOffset(),
         peer_uuid: peer_uuid,
         peer_id: socket.id,
         peer_name: peer_name,


### PR DESCRIPTION
User/Peer info which comes with webhook events contains join time in local time zone for attendee but time value has no time zone info, so it is impossible to say when exactly user actually joined (or left) the meeting. Recently I've  tried to gather info about how much time user/peer was at the meeting and failed to do so since users have different time zones. To not break current API I'm proposing to add a timezone shift as a separate field to the webhook events. In this case it will be possible to calculate correct time for join and exit/disconnect events.