### PR TITLE
Fixup .env.template - rename AWS_S3_BUCKET_NAME to correct AWS_S3_BUCKET

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -215,7 +215,7 @@ IP_LOOKUP_ENABLED=false                           # Enable IP lookup functionali
 
 # AWS S3 Configuration  
 AWS_S3_ENABLED=false                              # Enable AWS S3 storage (true|false)  
-AWS_S3_BUCKET_NAME=mirotalk                       # Name of your S3 bucket (must exist)  
+AWS_S3_BUCKET=mirotalk                       # Name of your S3 bucket (must exist)  
 AWS_S3_ENDPOINT=                                  # Custom S3 endpoint URL (leave empty to auto-resolve from region). Useful for S3-compatible services like MinIO, Wasabi, DigitalOcean Spaces, etc.
 AWS_S3_FORCE_PATH_STYLE=false                     # Use path-style URLs for S3-compatible storage (true|false). Set to true for MinIO, Wasabi, etc.
 AWS_ACCESS_KEY_ID=                                # AWS Access Key ID (leave empty for IAM roles)  


### PR DESCRIPTION
From: https://forum.cloudron.io/post/115461

The env processed is `AWS_S3_BUCKET` and not `AWS_S3_BUCKET_NAME`:
https://github.com/miroslavpejic85/mirotalksfu/blob/e59b24bb37a7b19560a03de1a5abb5fb79a2c6b4/app/src/config.template.js#L961 

https://github.com/miroslavpejic85/mirotalksfu/blob/e59b24bb37a7b19560a03de1a5abb5fb79a2c6b4/app/src/Server.js#L1118 