### PR TITLE
fixed WakeLock.js faulty script src path

### DIFF
--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -123,7 +123,7 @@
         <script defer src="../js/FixWebmDuration.js"></script>
         <script defer src="../js/RoomClient.js"></script>
         <script defer src="../js/Room.js"></script>
-        <script defer src="../js/wakeLock.js"></script>
+        <script defer src="../js/WakeLock.js"></script>
         <script defer src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
         <script defer src="https://cdn.jsdelivr.net/npm/qrious@4.0.2/dist/qrious.min.js"></script>
         <script defer src="https://cdn.jsdelivr.net/npm/fabric@5.3.0-browser/dist/fabric.min.js"></script>


### PR DESCRIPTION
On hosts with case sensitive file systems this resulted in 404 error page being embedded as javascript resulting in nasty popups telling us "ReferenceError: applyKeepAwake is not defined".

<img width="589" height="702" alt="image" src="https://github.com/user-attachments/assets/7e55f131-f0a6-4992-b7f2-f03ee6a28248" />


