### PR TITLE
Fix: Race condition in client initialization causing undefined socket.id

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -347,7 +347,9 @@ let quill = null;
 
 document.addEventListener('DOMContentLoaded', function () {
     initCursorLightEffect();
-    initClient();
+    socket.once('connect', () => {
+        initClient();
+    });
 });
 
 // ####################################################


### PR DESCRIPTION
# Fix: Intermittent Race Condition in Client Initialization

### 📂 Affected File
- `public/js/Room.js`

### 🎦 Visual Proof
| 🐞Bug Reproduced| ✅Fix Verified|
| ----------- | ----------- |
| <video autoplay src="https://github.com/user-attachments/assets/1f878140-b24f-402c-9b35-8db48a37b9c5">|  <video autoplay src="https://github.com/user-attachments/assets/e67700c6-626a-41b2-aa0e-d3924afdf911"/>|

### 🔍 Problem Description
A **race condition** was identified when users joined a meeting via a direct link (e.g., `https://127.0.0.1:3010/join?room=testroom&name=random&notify=0`).

* **The Issue:** The `initClient()` logic was occasionally executed before the Socket.io handshake was fully established.
* **The Consequence:** Because the connection wasn't ready, `socket.id` returned `undefined`. This led to backend logic errors, such as the "Username already in use" exception, even when the username was unique.

### 🛠 Technical Changes
Modified the initialization trigger in `public/js/Room.js`. Instead of running immediately on `DOMContentLoaded`, the client initialization now waits for a successful socket connection.
```diff
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -347,7 +347,9 @@
 document.addEventListener('DOMContentLoaded', function () {
     initCursorLightEffect();
-    initClient();
+    socket.once('connect', () => {
+        initClient();
+    });
 });
```

### ✨ Key Effects
* **Resolved Race Condition:** Guarantees that a valid `socket.id` is assigned before `initClient()` runs.
* **Ensured Idempotency:** By using `socket.once`, we prevent redundant initialization if the user experiences a network flicker and reconnects.